### PR TITLE
readme: add section on hardware requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,45 @@ If you want to run tests on the Protocol Labs Jupyterhub instance, see
 
 ### Requirements
 
+#### Hardware
+
+While no special hardware is needed to run the tests, running with a lot of test instances requires considerable CPU and
+RAM, and will likely exceed the capabilities of a single machine.
+
+A large workstation with many CPU cores can reasonably run a few hundred instances using the testground
+`local:docker` runner, although the exact limit will require some trial and error. In early testing we were able to
+run 500 containers on a 56 core Xeon W-3175X with 124 GiB of RAM, although it's possible we could run more
+now that we've optimized things a bit.
+
+It's useful to run with the `local:docker` or `local:exec` runners during test development, so long as you use
+fairly small instance counts (~25 or so works fine on a 2018 13" MacBook Pro with 16 GB RAM).
+
+When using the `local:docker` runner, it's a good idea to periodically garbage collect the docker images created by
+testground using `docker system prune` to reclaim disk space.
+
+To run larger tests like the ones in the [saved configurations](#saved-test-configurations), you'll need a
+kubernetes cluster. 
+
+If you have access to our [shared Jupyterhub instance](./README-shared-environment.md), your environment should already
+be set up to create and manage a cluster in our AWS project.
+
+To create your own cluster, follow the directions in the [testground/infra repo](https://github.com/testground/infra)
+to provision a cluster on AWS, and configure your tests to use the `cluster:k8s` test runner.
+
+The testground daemon process can be running on your local machine, as long as it has access to the k8s cluster.
+The machine running the daemon must have Docker installed, and the user account must have permission to use
+docker and have the correct AWS credentials to connect to the cluster. 
+When running tests on k8s, the machine running the testground daemon doesn't need a ton of resources,
+but ideally it should have a fast internet connection to push the Docker images to the cluster.
+
+Running the analysis notebooks benefits from multiple cores and consumes quite a bit of RAM, especially on the first
+run when it's converting data to pandas format. It's best to have at least 8 GB of RAM free when running the analysis
+notebook for the first time. 
+
+Also note that closing the browser tab containing a running Jupyter notebook does not stop the python kernel and reclaim
+the memory used. It's best to select `Close and Halt` from the Jupyter `File` menu when you're done with the analysis 
+notebook instead of just closing the tab.
+
 #### Testground
 
 You'll need to have the [testground](https://github.com/testground/testground) binary built and accessible


### PR DESCRIPTION
@willscott had a great observation that we could use some explanation about the requirements for actually running these tests in a production environment.

This adds a hardware requirements section to explain why you need a kubernetes cluster to run with the instance counts in the saved configurations, and some advice on RAM requirements for running the analysis notebooks.