### PR TITLE
Change `git` to `https`

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -197,7 +197,7 @@ def pubsub_commit(ref_str):
     if re.match(r'\b([a-f0-9]{40})\b', ref_str):
         return ref_str
 
-    out = subprocess.run(['git', 'ls-remote', 'git://github.com/libp2p/go-libp2p-pubsub'],
+    out = subprocess.run(['git', 'ls-remote', 'https://github.com/libp2p/go-libp2p-pubsub'],
                          check=True, capture_output=True, text=True)
 
     # look for matching branch or tag in output


### PR DESCRIPTION
Using `git` in the URL can cause it to hang and time-out.  I encountered this issue on Linux Mint.  It's also discussed [here](https://github.com/adaptlearning/adapt_authoring/issues/1431).  This fixes the issue.